### PR TITLE
changed setup url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email='james.lucas@berkeley.edu',
     description='Digest and assemble DNA',
     long_description=readme,
-    url='https://github.com/jaaamessszzz/DNAssembly',
+    url='https://github.com/outpace-bio/dnassembly',
     keywords=[
         'DNA',
         'assembly',


### PR DESCRIPTION
URL used in setup method call was not modified from original fork, thus the setup method would install the incorrect repository. This commit fixes that issue and has been validated with listed module exports.